### PR TITLE
Add missing output to docker

### DIFF
--- a/cluster-entrypoint.sh
+++ b/cluster-entrypoint.sh
@@ -8,14 +8,11 @@ chmod 400 /var/lib/rabbitmq/.erlang.cookie
 # Get hostname from enviromant variable
 HOSTNAME=`env hostname`
 echo "Starting RabbitMQ Server For host: " $HOSTNAME
+/usr/local/bin/docker-entrypoint.sh rabbitmq-server &
+sleep 5
+rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbit\@$HOSTNAME.pid
 
-if [ -z "$JOIN_CLUSTER_HOST" ]; then
-    /usr/local/bin/docker-entrypoint.sh rabbitmq-server &
-    sleep 5
-    rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbit\@$HOSTNAME.pid
-else
-    /usr/local/bin/docker-entrypoint.sh rabbitmq-server -detached
-    sleep 5
+if [ -n "$JOIN_CLUSTER_HOST" ]; then
     rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbit\@$HOSTNAME.pid
     rabbitmqctl stop_app
     rabbitmqctl join_cluster rabbit@$JOIN_CLUSTER_HOST

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     entrypoint: /usr/local/bin/cluster-entrypoint.sh
 
   haproxy:
-    image: haproxy:1.7
+    image: haproxy:latest
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     depends_on:

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,5 +1,5 @@
 global
-        log 127.0.0.1   local1
+        log stdout format raw local0
         maxconn 4096
  
 defaults


### PR DESCRIPTION
1. Adds haproxy to output of `docker compose up`
2. Fixes an issue where only rabbitm1 node was visible in output of `docker compose up`. Now all nodes are.
3. Updates haproxy